### PR TITLE
v0.2.4 PR

### DIFF
--- a/ItemPool.py
+++ b/ItemPool.py
@@ -471,15 +471,63 @@ def get_items_to_exclude(world: "PaperMarioWorld") -> list:
 def get_locations_to_exclude(world: "PaperMarioWorld") -> list:
     excluded_locations = []
 
-    # remove merlow rewards
+    # exclude locations which require more star spirits than are expected to be needed to beat the seed
+    if not world.options.power_star_hunt.value:
+        if world.options.star_spirits_required.value < 6:
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 20")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 19")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 18")
+        if world.options.star_spirits_required.value < 5:
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 17")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 16")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 15")
+            excluded_locations.append("TT Gate District Dojo: Master 3")
+            excluded_locations.append("TT Port District Radio Trade Event 3 Reward")
+        if world.options.star_spirits_required.value < 4:
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 14")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 13")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 12")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 5 - 3")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 5 - 2")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 5 - 1")
+            excluded_locations.append("TT Gate District Dojo: Master 2")
+        if world.options.star_spirits_required.value < 3:
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 11")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 10")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 9")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 4 - 3")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 4 - 2")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 4 - 1")
+            excluded_locations.append("TT Gate District Dojo: Master 1")
+            excluded_locations.append("TT Port District Radio Trade Event 2 Reward")
+        if world.options.star_spirits_required.value < 2:
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 8")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 7")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 6")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 3 - 3")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 3 - 2")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 3 - 1")
+        if world.options.star_spirits_required.value < 1:
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 5")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 4")
+            excluded_locations.append("KR Koopa Village 2 Koopa Koot Reward 3")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 2 - 3")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 2 - 2")
+            excluded_locations.append("TT Plaza District Rowf's Shop Set 2 - 1")
+            excluded_locations.append("TT Gate District Dojo: Lee")
+            excluded_locations.append("TT Port District Radio Trade Event 1 Reward")
+
+    # exclude merlow rewards
     if not world.options.merlow_items.value:
         excluded_locations.extend(location_groups["MerlowReward"])
 
-    # remove rowf item locations
+    # exclude rowf item locations
     if not world.options.rowf_items.value:
-        excluded_locations.extend(location_groups["RowfShop"])
+        for location in location_groups["RowfShop"]:
+            if location not in excluded_locations:
+                excluded_locations.append(location)
 
-    # remove rip cheato locations
+    # exclude rip cheato locations
     for i in range(0, 11):
         location_name = location_groups["RipCheato"][i]
         if location_table[location_name][5] >= world.options.cheato_items.value:

--- a/PM Sample.yaml
+++ b/PM Sample.yaml
@@ -10,6 +10,7 @@ Paper Mario:
     # Many settings do not affect logic or generation in any way and will only be relevant when an actual file gets created. These will be marked (NLA).
     # Changing these settings is usually fine, just don't be too surprised if they don't work. If you have generation issues or crash issues, leave them as is to ensure they aren't the cause.
     
+    # AP World Version: 0.2.4
 
     # Items
     keysanity: True                         # Other options: False
@@ -55,7 +56,7 @@ Paper Mario:
     random_puzzles: False                   # Other options: True (NYI)
 
     # General Difficulty
-    enemy_difficulty: progressive_scaling   # Other options: shuffle_chapter_difficulty (NYI), progressive_scaling
+    enemy_difficulty: progressive_scaling   # Other options: shuffle_chapter_difficulty, progressive_scaling
     enemy_damage: Normal                    # Other options: double_pain, quadruple_pain
     cap_enemy_xp: False                     # Other options: True
     enemy_xp_multiplier: 2                  # Other options: 0-2

--- a/PM Sample.yaml
+++ b/PM Sample.yaml
@@ -52,7 +52,7 @@ Paper Mario:
     partner_fp_shuffle: vanilla             # Other options: balanced_random, shuffled, fully_random
     sp_shuffle: vanilla                     # Other options: balanced_random, shuffled, fully_random
     mystery_shuffle: vanilla                # Other options: random_pick, random_per_use
-    formation_shuffle: False                # Other options: True (NYI)
+    formation_shuffle: False                # Other options: True
     random_puzzles: False                   # Other options: True (NYI)
 
     # General Difficulty

--- a/Rom.py
+++ b/Rom.py
@@ -191,12 +191,12 @@ def generate_output(world, output_dir: str) -> None:
 
     # enemy stats
     enemy_stats, chapter_changes = get_shuffled_chapter_difficulty(
-        world.options.enemy_difficulty.value, starting_chapter=1)
+        world.options.enemy_difficulty.value, starting_chapter=world.options.starting_map.value)
 
     battle_formations = []
 
-    if (world.options.formation_shuffle.value or
-            world.options.enemy_difficulty.value == EnemyDifficulty.option_Progressive_Scaling):
+    if (world.options.formation_shuffle.value
+            or world.options.enemy_difficulty.value == EnemyDifficulty.option_Progressive_Scaling):
         battle_formations = get_random_formations(chapter_changes,
                                                   world.options.enemy_difficulty.value ==
                                                   EnemyDifficulty.option_Progressive_Scaling)

--- a/RomTable.py
+++ b/RomTable.py
@@ -4,7 +4,7 @@ from .data.RomOptionList import rom_option_table, ap_to_rom_option_table
 from .data.palettes_meta import MENU_COLORS
 from .modules.random_blocks import get_block_key
 from .options import (EnemyDamage, PaperMarioOptions, PartnerUpgradeShuffle, ShuffleKootFavors, ShuffleLetters,
-                      BowserCastleMode, StatusMenuColorPalette)
+                      BowserCastleMode, StatusMenuColorPalette, EnemyDifficulty)
 from .data.MysteryOptions import MysteryOptions
 from .data.starting_maps import starting_maps
 from .data.node import Node
@@ -27,7 +27,7 @@ class RomTable:
     def __getitem__(self, key):
         return self.db[key]
 
-    def generate_pairs(self,  options: PaperMarioOptions, placed_items: list[Node], placed_blocks: dict, entrances: list,
+    def generate_pairs(self, options: PaperMarioOptions, placed_items: list[Node], placed_blocks: dict, entrances: list,
                        actor_attributes: list, move_costs: list, palettes: list, quizzes: list, music_list: list,
                        mapmirror_list: list, puzzle_list: list, mystery_opts: MysteryOptions, required_spirits: list):
         table_data = []
@@ -255,6 +255,8 @@ def get_dbtuples(options: PaperMarioOptions, mystery_opts: MysteryOptions, requi
                     option_value = options.enemy_damage.value == EnemyDamage.option_Double_Pain
                 case "QuadrupleDamage":
                     option_value = options.enemy_damage.value == EnemyDamage.option_Quadruple_Pain
+                case "ProgressiveScaling":
+                    option_value = options.enemy_difficulty.value == EnemyDifficulty.option_Progressive_Scaling
                 case "EnabledCheckBits":
                     option_value = map_tracker_check_bits
                 case "EnabledShopBits":

--- a/__init__.py
+++ b/__init__.py
@@ -147,8 +147,8 @@ class PaperMarioWorld(World):
                 lcl_warnings += "\n'gear_shuffle_mode' must be set to full_shuffle"
             if not self.options.keysanity.value:
                 lcl_warnings += "\n'keysanity' must be set to True"
-            if self.options.merlow_items.value:
-                lcl_warnings += "\n'merlow_items' must be set to False"
+            # if self.options.merlow_items.value:
+            #     lcl_warnings += "\n'merlow_items' must be set to False"
             if not self.options.partners.value:
                 lcl_warnings += "\n'partners' must be set to True"
 
@@ -161,7 +161,6 @@ class PaperMarioWorld(World):
             raise ValueError(f"Paper Mario: {self.player} ({self.multiworld.player_name[self.player]}) has limit "
                              "chapter logic set to true. Specific star spirits must also be set to true if you wish to "
                              "limit chapter logic")
-
 
         # Make sure it doesn't try to shuffle Koot coins if rewards aren't shuffled
         if self.options.koot_favors.value == ShuffleKootFavors.option_Vanilla:
@@ -585,6 +584,15 @@ class PaperMarioWorld(World):
 
     def generate_output(self, output_directory: str):
         generate_output(self, output_directory)
+
+    # handle star pieces from quizmo, triple star piece items
+    def collect(self, state: CollectionState, item: PMItem) -> bool:
+        if item.name == "3x Star Pieces":
+            state.prog_items[self.player]["Star Piece"] += 3
+        # Quizmo star pieces are events that can exist in multiple places, format "StarPiece_MAC_1"
+        elif item.name.startswith("StarPiece_") and state.prog_items[self.player][item.name] == 1:
+            state.prog_items[self.player]["Star Piece"] += 1
+        return super().collect(state, item)
 
     def get_locations(self):
         return self.multiworld.get_locations(self.player)

--- a/__init__.py
+++ b/__init__.py
@@ -147,8 +147,6 @@ class PaperMarioWorld(World):
                 lcl_warnings += "\n'gear_shuffle_mode' must be set to full_shuffle"
             if not self.options.keysanity.value:
                 lcl_warnings += "\n'keysanity' must be set to True"
-            # if self.options.merlow_items.value:
-            #     lcl_warnings += "\n'merlow_items' must be set to False"
             if not self.options.partners.value:
                 lcl_warnings += "\n'partners' must be set to True"
 

--- a/__init__.py
+++ b/__init__.py
@@ -29,7 +29,8 @@ from .modules.random_actor_stats import get_shuffled_chapter_difficulty
 from .Rules import set_rules
 from .modules.random_partners import get_rnd_starting_partners
 from .options import (EnemyDifficulty, PaperMarioOptions, ShuffleKootFavors, PartnerUpgradeShuffle, HiddenBlockMode,
-                      ShuffleSuperMultiBlocks, GearShuffleMode, StartingMap, BowserCastleMode, ShuffleLetters)
+                      ShuffleSuperMultiBlocks, GearShuffleMode, StartingMap, BowserCastleMode, ShuffleLetters,
+                      ItemTraps, MirrorMode)
 from .data.node import Node
 from .data.starting_maps import starting_maps
 from .Rom import generate_output
@@ -129,6 +130,27 @@ class PaperMarioWorld(World):
 
     # Do some housekeeping before generating, namely fixing some options that might be incompatible with each other
     def generate_early(self) -> None:
+
+        # fail generation if attempting to use options that are not fully implemented yet
+        nyi_warnings = ""
+        if self.options.local_consumables.value != 100:
+            nyi_warnings += "\n'local_consumables' must be set to 100"
+        if self.options.random_puzzles.value:
+            nyi_warnings += "\n'random_puzzles' must be set to False"
+        if self.options.item_traps.value != ItemTraps.option_No_Traps:
+            nyi_warnings += "\n'item_traps' must be set to No_Traps"
+        if self.options.shuffle_dungeon_entrances.value:
+            nyi_warnings += "\n'shuffle_dungeon_entrances' must be set to False"
+        if self.options.mirror_mode.value == MirrorMode.option_Static_Random:
+            nyi_warnings += "\n'mirror_mode' cannot be set to Static_Random"
+        if self.options.start_with_random_items.value:
+            nyi_warnings += "\n'start_with_random_items' must be set to False"
+
+        if nyi_warnings:
+            nyi_warnings = ((f"Paper Mario: {self.player} ({self.multiworld.player_name[self.player]}) has settings "
+                             "are not yet implemented in the .apworld being used for generation. "
+                             "Please check for a newer release and/or adjust the settings below : ") + nyi_warnings)
+            raise ValueError(nyi_warnings)
 
         # Unclear which type of game is desired, raise error and have the player choose
         if self.options.require_specific_spirits.value and self.options.power_star_hunt.value:

--- a/data/ItemList.py
+++ b/data/ItemList.py
@@ -18,7 +18,7 @@ item_table = {
     "Third Degree Card":        ("KEYITEM",        Ic.filler,                     12,     50,     False,  False,  False),
     "Fourth Degree Card":       ("KEYITEM",        Ic.filler,                     13,     50,     False,  False,  False),
     "Diploma":                  ("KEYITEM",        Ic.filler,                     14,     50,     False,  False,  False),
-    "Ultra Stone":              ("KEYITEM",        Ic.filler,                     15,     50,     False,  False,  False),
+    "Ultra Stone":              ("KEYITEM",        Ic.useful,                     15,     50,     False,  False,  False),
     "Koopa Fortress Key":       ("KEYITEM",        Ic.progression,                16,     50,     False,  False,  False),
     "Ruins Key":                ("KEYITEM",        Ic.progression,                17,     50,     False,  False,  False),
     "Pulse Stone":              ("KEYITEM",        Ic.progression,                18,     50,     False,  False,  False),

--- a/data/RomOptionList.py
+++ b/data/RomOptionList.py
@@ -134,7 +134,7 @@ ap_to_rom_option_table = {
     "MuteDangerBeeps": "mute_danger_beeps",
 
     # Difficulty and enemies
-    "ProgressiveScaling": "enemy_difficulty",
+    "ProgressiveScaling": "",
     "ChallengeMode": "",  # NYI, always false
     "CapEnemyXP": "cap_enemy_xp",
     "XPMultiplier": "",

--- a/modules/random_actor_stats.py
+++ b/modules/random_actor_stats.py
@@ -41,17 +41,6 @@ def get_shuffled_chapter_difficulty(
         all_enemy_stats[actor_name]["NativeChapter"] = actor_native_chapter
         all_enemy_stats[actor_name][actor_stat_name] = actor_stat_values
 
-    # Random chance for enemy promotion: 20%
-    for actor_name in all_enemy_stats:
-        if not shuffle_chapter_difficulty:
-            all_enemy_stats[actor_name]["Promoted"] = False
-        else:
-            all_enemy_stats[actor_name]["Promoted"] = False
-
-    for actor_name in all_enemy_stats:
-        if all_enemy_stats[actor_name]["Promoted"]:
-            print(f"Promoted {actor_name}")
-
     # Randomize chapter order
     chapters_to_shuffle = [1, 2, 3, 4, 5, 6, 7]
     if shuffle_chapter_difficulty:
@@ -91,8 +80,6 @@ def get_shuffled_chapter_difficulty(
                 # Special case for Dojo / Kent
                 native_chapter = 1
             value = int(all_enemy_stats[actor_name][actor_stat_name][chapter_dict.get(native_chapter) - 1])
-            if all_enemy_stats[actor_name]["Promoted"]:
-                value = int(all_enemy_stats[actor_name][actor_stat_name][chapter_dict.get(native_chapter) + 1])
 
         new_enemy_stats.append((dbkey, value))
 

--- a/options.py
+++ b/options.py
@@ -518,7 +518,7 @@ class StartingMap(Choice):
     option_Toad_Town = 0
     option_Goomba_Village = 1
     option_Dry_Dry_Outpost = 2
-    option_Yoshi_Village = 3
+    option_Yoshi_Village = 5
 
 
 class OpenPrologue(Toggle):

--- a/options.py
+++ b/options.py
@@ -14,7 +14,7 @@ class ShuffleKeys(DefaultOnToggle):
 
 class ShuffleTradeEvents(Toggle):
     """Adds the 3 rewards obtained for doing the Trading Toad quests (started via Koopa Village's radio) in the item
-    pool. These are available with 0, 2, and 5 star spirits saved."""
+    pool. These are available with 1, 3, and 5 star spirits saved."""
     display_name = "Include Trading Event Rewards"
 
 


### PR DESCRIPTION
# New features
- Shuffle_Chapter_Difficulty is now working for the enemy_difficulty setting. This means that instead of vanilla or progressively scaling hp and damage values, each chapter is assigned a difficulty from 1-7 which approximates the stats to match that chapter number's difficulty level.

- Formation_Shuffle is now working. Setting this to true will make it so that enemies will appear in random numbers and formations that may not exist in the original game. Enemies will still only exist in the chapter they are normally found.



# Changes to existing features
- Added logic handling for quizmo and triple star piece items
- LCL now allows the use of merlow_items setting
- Locations requiring more star spirits than the star_spirits_required setting now get marked as excluded, meaning they will always contain junk items. This goes for Koot, Rowf, Dojo, and Trade locations.

# Bugfixes/Corrections
- Star spirit requirements in the trade events setting description are now correct (was 0, 2, 5, corrected to 1, 3, 5)

# Other
- Ultra Stone is now considered useful
- Attempting to generate a game with options that aren't implemented will result in an error and generation will fail

