### PR TITLE
fix: validation error against games smaller than 32mb

### DIFF
--- a/client.py
+++ b/client.py
@@ -31,12 +31,12 @@ class PaperMarioClient(BizHawkClient):
 
         try:
             # Check ROM name/patch version
-            game_names = await bizhawk.read(ctx.bizhawk_ctx, [(0x20, 0x14, "ROM"),
-                                                              (TABLE_ADDRESS, 0x4, "ROM")])
-            if game_names[0].decode("ascii") != "PAPER MARIO         ":
+            game_name = await bizhawk.read(ctx.bizhawk_ctx, [(0x20, 0x14, "ROM")])
+            if game_name[0].decode("ascii") != "PAPER MARIO         ":
                 return False
 
-            if game_names[1] != MAGIC_VALUE:
+            pmr_magic_value = await bizhawk.read(ctx.bizhawk_ctx, [(TABLE_ADDRESS, 0x4, "ROM")])
+            if pmr_magic_value[0] != MAGIC_VALUE:
                 logger.info("This Paper Mario ROM is invalid.")
                 return False
 


### PR DESCRIPTION
Separating the generic check for a Paper Mario ROM and the specific check for the Paper Mario Randomizer ROM avoids validation errors against ROMs where the specific check would attempt to read outside of the valid ROM range.

This was first encountered on 2025-01-04 and reported on discord by user polterghost as this message:
```
Connector script returned errors (1 sub-exception)
  + Exception Group Traceback (most recent call last):
  |   File "worlds\_bizhawk\context.py", line 261, in main
  |   File "worlds\_bizhawk\context.py", line 173, in _game_watcher
  |   File "worlds\_bizhawk\client.py", line 61, in get_handler
  |   File "C:\ProgramData\Archipelago\custom_worlds\papermario.apworld\papermario\client.py", line 34, in validate_rom
  |     game_names = await bizhawk.read(ctx.bizhawk_ctx, [(0x20, 0x14, "ROM"),
  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "worlds\_bizhawk\__init__.py", line 278, in read
  |   File "worlds\_bizhawk\__init__.py", line 243, in guarded_read
  |   File "worlds\_bizhawk\__init__.py", line 138, in send_requests
  | ExceptionGroup: Connector script returned errors (1 sub-exception)
  +-+---------------- 1 ----------------
    | worlds._bizhawk.ConnectorError: Unknown error
    +------------------------------------
```

User liquidcat64 then remarked:
```
I think I see what the problem is; during validation, PM is trying to read an address that, in CV64, is well out of the ROM's size. IIRC some NES games hit a similar issue.

Being a 12mb game, the highest ROM address CV64 can read from is 0xBFFFFF. PM (which is a 32mb game) is trying to read 0x1D00000 out of CV64. 
```