### PR TITLE
Logic fix for bowser's_castle.json

### DIFF
--- a/data/regions/bowser's_castle.json
+++ b/data/regions/bowser's_castle.json
@@ -794,7 +794,7 @@
     "map_id": "48",
     "map_name": "Left Water Puzzle",
     "locations": {
-      "BC Left Water Puzzle Top Left Ledge": "can_use_ability_sushie and 'RF_WaterLevel2'"
+      "BC Left Water Puzzle Top Left Ledge": "can_use_ability_sushie and 'RF_WaterLevel3'"
     },
     "exits": {
       "BC Right Water Puzzle 3F": "True"


### PR DESCRIPTION
It's not possible to reach the item on BC Left Water Puzzle 3F without first raising the water to 3 (which requires the Ultra Boots; I had a seed where Progressive Boots generated up there, making them impossible to reach)